### PR TITLE
Call treeView.createView if not yet created.

### DIFF
--- a/lib/tree-view-autoresize.coffee
+++ b/lib/tree-view-autoresize.coffee
@@ -46,6 +46,8 @@ module.exports = TreeViewAutoresize =
 
     else
       requirePackages('tree-view').then ([treeView]) =>
+        unless treeView.treeView?
+          treeView.createView()
         @treeView = treeView.treeView
         @treeView.on 'click.autoresize', '.directory', (=> @resizeTreeView())
         @subscriptions.add atom.project.onDidChangePaths (=> @resizeTreeView())


### PR DESCRIPTION
This fixes a bug where `@treeView` is null when Atom is launched with the tree-view closed.