### PR TITLE
Configurable timings, fit vert scrollbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "atom-utils": "^0.9.2",
-    "jquery": "^2.2.2"
+    "jquery": "^2.2.2",
+    "scrollbar-width": "^3.1.1"
   }
 }


### PR DESCRIPTION
It was choosing sizes that needed a horizontal scrollbar anytime I had
enough files visible to need a vertical scrollbar. I've attempted to
avoid this by including the vertical scrollbar width in the default
padding. Only the default tree is changed because I don't use Nuclide.

Also create some settings to allow the user to speed up or slow down
the animations if desired, defaulting to the previously hard coded
values. Both the default tree and Nuclide are changed for this.