### PR TITLE
Suppress horizontal scrollbar

### DIFF
--- a/lib/tree-view-autoresize.coffee
+++ b/lib/tree-view-autoresize.coffee
@@ -26,6 +26,7 @@ module.exports = TreeViewAutoresize =
   subscriptions: null
   conf: []
   delayMs: 100
+  scrollbarWidth: require('scrollbar-width')()
 
   activate: () ->
     requestIdleCallback =>
@@ -114,8 +115,8 @@ module.exports = TreeViewAutoresize =
 
   generateCss: ->
     css = "
-      atom-dock.left .atom-dock-open .atom-dock-content-wrapper:not(:active),
-      atom-dock.left .atom-dock-open .atom-dock-mask:not(:active),
+      atom-dock.left  .atom-dock-open .atom-dock-content-wrapper:not(:active),
+      atom-dock.left  .atom-dock-open .atom-dock-mask:not(:active),
       atom-dock.right .atom-dock-open .atom-dock-content-wrapper:not(:active),
       atom-dock.right .atom-dock-open .atom-dock-mask:not(:active) {
         transition: width #{@conf['animationMilliseconds']}ms linear;
@@ -128,7 +129,7 @@ module.exports = TreeViewAutoresize =
         atom-dock.right .atom-dock-open .atom-dock-mask {
           min-width: #{@conf['minimumWidth']}px;
         }
-        atom-dock.left .atom-dock-open .atom-dock-mask .atom-dock-content-wrapper,
+        atom-dock.left  .atom-dock-open .atom-dock-mask .atom-dock-content-wrapper,
         atom-dock.right .atom-dock-open .atom-dock-mask .atom-dock-content-wrapper {
           min-width: #{@conf['minimumWidth']}px;
         }
@@ -140,18 +141,21 @@ module.exports = TreeViewAutoresize =
         atom-dock.right .atom-dock-open .atom-dock-mask {
           max-width: #{@conf['maximumWidth']}px;
         }
-        atom-dock.left .atom-dock-open .atom-dock-mask .atom-dock-content-wrapper,
+        atom-dock.left  .atom-dock-open .atom-dock-mask .atom-dock-content-wrapper,
         atom-dock.right .atom-dock-open .atom-dock-mask .atom-dock-content-wrapper {
           max-width: #{@conf['maximumWidth']}px;
         }
       "
 
-    if @conf['padding']
-      css += "
-        atom-dock.left .tree-view .full-menu,
-        atom-dock.right .tree-view .full-menu {
-          padding-right: #{@conf['padding']}px;
-        }
-      "
+    css += "
+      atom-dock.left  .tree-view .full-menu,
+      atom-dock.right .tree-view .full-menu {
+        padding-right: #{@conf['padding']+@scrollbarWidth}px;
+      }
+      atom-dock.left  .tree-view,
+      atom-dock.right .tree-view {
+        overflow-x: hidden;
+      }
+    "
 
     css

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "atom": ">=1.17.0 <2.0.0"
   },
   "dependencies": {
-    "atom-utils": "^0.9.2"
+    "atom-utils": "^0.9.2",
+    "scrollbar-width": "^3.1.1"
   }
 }


### PR DESCRIPTION
My horizontal scrollbar came back, because that part of #10 was not preserved in the switchover to a more CSS-based approach in e11bb53. These changes banish it again. Not sure if you'd want these changes, but I'm using them, and I figured I might as well offer them.

- Add scrollbar width to tree view padding
- Set horizontal overflow to hidden